### PR TITLE
Split day end report to new file to permit assigning jobs during day

### DIFF
--- a/src/events/day-end-report.tw
+++ b/src/events/day-end-report.tw
@@ -1,0 +1,4 @@
+:: Day End Report[nobr TimeNone]
+	/* list each slave and allow assignment to tasks. */
+	
+	<<goto "Your Room">>


### PR DESCRIPTION
Add an option at the beginning of the day to assign current slaves to jobs or punishments during the day.  Will also need to modify locations/dungeon to reflect their current assignments.